### PR TITLE
Fix method name and argument name

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/pkcs11.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs11.rb
@@ -61,7 +61,7 @@ class Hiera
              when 'pkcs11'
                result = self.session(:encrypt,plaintext)
              when 'mri-pkcs11'
-               result = self.mri_pkcs11(:encrypt,plaintext)
+               result = self.mri_session(:encrypt,plaintext)
              when 'openssl'
                result = self.openssl(:encrypt,plaintext)
              else
@@ -78,7 +78,7 @@ class Hiera
              when 'pkcs11'
                result = self.session(:decrypt,ciphertext)
              when 'mri-pkcs11'
-                 result = self.mri_pkcs11(:decrypt,ciphertext)
+                 result = self.mri_session(:decrypt,ciphertext)
              when 'openssl'
                result = self.openssl(:decrypt,ciphertext)
              else

--- a/lib/hiera/backend/eyaml/encryptors/pkcs11.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs11.rb
@@ -78,7 +78,7 @@ class Hiera
              when 'pkcs11'
                result = self.session(:decrypt,ciphertext)
              when 'mri-pkcs11'
-                 result = self.mri_pkcs11(:decrypt,plaintext)
+                 result = self.mri_pkcs11(:decrypt,ciphertext)
              when 'openssl'
                result = self.openssl(:decrypt,ciphertext)
              else


### PR DESCRIPTION
- Changed `plaintext` to `ciphertext` in `mri-pkcs11` decrypt
- Fixed method name: `mri_session` instead of `mri_pkcs11`
